### PR TITLE
Export Route Table ID

### DIFF
--- a/aws/network/public_subnet/main.tf
+++ b/aws/network/public_subnet/main.tf
@@ -61,3 +61,5 @@ resource "aws_network_acl" "public" {
 */
 
 output "subnet_ids" { value = "${join(",", aws_subnet.public.*.id)}" }
+
+output "route_table_id" { value = "${aws_route_table.public.id}" }


### PR DESCRIPTION
Export Route Table id, so that it can be used to modify the routing table
