### PR TITLE
Allow multiple instances of bastion module

### DIFF
--- a/aws/network/bastion/main.tf
+++ b/aws/network/bastion/main.tf
@@ -1,25 +1,27 @@
 variable "name" {
   default = "bastion"
 }
-variable "instance_type" {
-}
-variable "region" {
-}
-variable "iam_instance_profile" {
-}
-variable "vpc_id" {
-}
-variable "vpc_cidr" {
-}
-variable "subnet_ids" {
-}
-variable "user_data" {
-}
-variable "ami" {
-}
+
+variable "instance_type" {}
+
+variable "region" {}
+
+variable "iam_instance_profile" {}
+
+variable "vpc_id" {}
+
+variable "vpc_cidr" {}
+
+variable "subnet_ids" {}
+
+variable "user_data" {}
+
+variable "ami" {}
+
 variable "owner" {
   default = ""
-} 
+}
+
 variable "extra_security_groups" {
   description = "Additional list of security groups the Bastion instance shall have, that are not created by the module"
 
@@ -28,12 +30,12 @@ variable "extra_security_groups" {
 }
 
 resource "aws_security_group" "bastion" {
-  name        = "${var.name}"
+  name_prefix = "${var.name}-"
   vpc_id      = "${var.vpc_id}"
   description = "Bastion security group"
 
   tags {
-    Name = "${var.name}"
+    Name  = "${var.name}"
     Owner = "${var.owner}"
   }
 
@@ -60,43 +62,45 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_security_group" "ssh_from_bastion" {
-  name = "ssh_from_bastion"
+  name_prefix = "ssh_from_bastion"
   description = "Allow ssh from bastion hosts"
-  vpc_id = "${var.vpc_id}"
+  vpc_id      = "${var.vpc_id}"
 
   tags {
-    Name = "ssh_from_bastion"
+    Name  = "ssh_from_bastion"
     Owner = "${var.owner}"
   }
 
   ingress {
-      from_port = 22
-      to_port = 22
-      protocol = "tcp"
-      security_groups = ["${aws_security_group.bastion.id}"]
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.bastion.id}"]
   }
 
   egress {
-      from_port = 0
-      to_port = 0
-      protocol = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
 resource "aws_instance" "bastion" {
-  ami                    = "${var.ami}"
-  instance_type          = "${var.instance_type}"
-  iam_instance_profile   = "${var.iam_instance_profile}"
-  subnet_id              = "${element(split(",", var.subnet_ids), count.index)}"
-  vpc_security_group_ids = [ "${aws_security_group.bastion.id}",
-                             "${var.extra_security_groups}"
-                           ]
-  user_data              = "${var.user_data}"
-  count                  = 1
+  ami                  = "${var.ami}"
+  instance_type        = "${var.instance_type}"
+  iam_instance_profile = "${var.iam_instance_profile}"
+  subnet_id            = "${element(split(",", var.subnet_ids), count.index)}"
+
+  vpc_security_group_ids = ["${aws_security_group.bastion.id}",
+    "${var.extra_security_groups}",
+  ]
+
+  user_data = "${var.user_data}"
+  count     = 1
 
   tags {
-    Name = "${var.name}"
+    Name  = "${var.name}"
     Owner = "${var.owner}"
   }
 }


### PR DESCRIPTION
Use name_prefix instead of name for security groups. This allows
multiple stacks to live next to each other.